### PR TITLE
add additional process check for machines running InterceptX

### DIFF
--- a/scripts/sophos.py
+++ b/scripts/sophos.py
@@ -18,6 +18,13 @@ def check_sophos_running():
     sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = sp.communicate()
 
+    if sp.returncode = 113:
+        # 10.x series with InterceptX uses com.sophos.scan.legacy - check for it
+        # instead if the original search doesn't find it.
+        cmd = ['/bin/launchctl', 'print', 'system/com.sophos.scan.legacy']
+        sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = sp.communicate()
+
     if 'state = running' in out:
         return True
     else:


### PR DESCRIPTION
InterceptX renames com.sophos.scan to com.sophos.scan.legacy. If launchctl print doesn't find the Endpoint job, we should look for the "legacy" rename job to check if Sophos is running rather than returning false negatives.